### PR TITLE
Correct reference to ruote-dm in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,3 @@
-
 = ruote-sequel
 
 Sequel storage implementation for ruote >= 2.2.0
@@ -6,7 +5,7 @@ Sequel storage implementation for ruote >= 2.2.0
 
 == usage
 
-This is how a ruote engine is setup with a ruote-dm storage (postgres) and a worker :
+This is how a ruote engine is setup with a ruote-sequel storage (postgres) and a worker :
 
   require 'rubygems'
   require 'json' # gem install json


### PR DESCRIPTION
Tiny correction for a copy/paste error I noticed when reading the README
